### PR TITLE
Updated pinpoint to node8.10

### DIFF
--- a/amplify/backend/analytics/reactnotes/pinpoint-cloudformation-template.json
+++ b/amplify/backend/analytics/reactnotes/pinpoint-cloudformation-template.json
@@ -199,7 +199,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [


### PR DESCRIPTION
Due to AWS deprecating node6.10, we need to update to node8.10 in the pinpoint-cloudformation-template file.