### PR TITLE
Updating analytics Lambda function to nodejs8.10

### DIFF
--- a/amplify/backend/analytics/reactnotes/pinpoint-cloudformation-template.json
+++ b/amplify/backend/analytics/reactnotes/pinpoint-cloudformation-template.json
@@ -199,7 +199,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [


### PR DESCRIPTION
nodejs6.10 runtime is no longer supported for new Lambda functions. New projects attempting to use this repo will see the error:
2019-10-29T20:47:25.459Z [INFO]: CREATE_FAILED PinpointFunction                                                     AWS::Lambda::Function      Tue Oct 29 2019 20:47:20 GMT+0000 (Coordinated Universal Time) The runtime parameter of nodejs6.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs10.x) while creating or updating functions. (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: ba22cc8d-c4e7-495c-9036-68352847d369)
                                 CREATE_FAILED react-notes-amplify-20191029204612-analyticsreactnotes-1J8OYEOPBEY1N AWS::CloudFormation::Stack Tue Oct 29 2019 20:47:21 GMT+0000 (Coordinated Universal Time) The following resource(s) failed to create: [PinpointFunction].
